### PR TITLE
v1.1.0: AI rate limiting, observability, and auth metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## [v1.1.0] - 2025-09-24
+
+### Added
+
+- AI endpoints (`AIController`) with deterministic categorize/insights and standard
+  rate limit headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`,
+  `X-RateLimit-Reset`, `Retry-After`.
+- Auth metrics counters for login/refresh success and failure.
+- Correlation ID propagation via `X-Correlation-Id` and structured JSON logging
+  (`logback-spring.xml`).
+- Resilience configuration scaffold (`resilience4j.yml`).
+- Frontend AI Assistant: dynamic cooldown from headers, remaining quota and
+  reset countdown; Dexie v4 history; global rate limit store; axios telemetry.
+
+### Changed
+
+- README updated with rate limit semantics and UI behavior.
+- Frontend dependency: `uuid` added for persistent correlation IDs.
+
+### Notes
+
+- Run `npm install` in `frontend/`.
+- No DB migrations (browser Dexie auto-upgrade).


### PR DESCRIPTION
This PR delivers production-grade observability and UX improvements for AI and auth.

Summary
- AI endpoints emit standard rate limit headers
- Frontend consumes headers for precise cooldown + quota display
- Auth flows emit success/failure counters (Micrometer)
- Correlation IDs propagated end-to-end; structured JSON logs
- Resilience scaffold (`resilience4j.yml`) for future external provider
- Secure refresh token rotation and Dexie v4 AI query history

Why
Improves transparency (remaining quota + reset), operations (metrics/logs), and readiness for external AI providers.

Scope
- Backend: `AIController`, headers on success/429, auth metrics, logging config, resilience config, refresh token infra
- Frontend: `AIAssistant.jsx` with dynamic cooldown + quota UI, global rate limit store, axios interceptors

Risk
Low (additive). Requires `npm install` for `uuid`.

Follow-ups
- Playwright 429 test
- Grafana panels for new counters
- External AI provider integration leveraging resilience4j

Reviewer checklist: see `.github/reviewer-checklist.md`